### PR TITLE
fix(middleware): Fix TypeError: Only byte strings can be passed to C code

### DIFF
--- a/freenasUI/middleware/notifier.py
+++ b/freenasUI/middleware/notifier.py
@@ -57,7 +57,7 @@ GELI_KEY_SLOT = 0
 GELI_RECOVERY_SLOT = 1
 SYSTEMPATH = '/var/db/system'
 PWENC_BLOCK_SIZE = 32
-PWENC_PADDING = '{'
+PWENC_PADDING = b'{'
 PWENC_CHECK = 'Donuts!'
 BACKUP_SOCK = '/var/run/backupd.sock'
 
@@ -660,6 +660,8 @@ class notifier:
         return secret
 
     def pwenc_encrypt(self, text):
+        if not isinstance(text, bytes):
+            text = text.encode('utf8')
         from Crypto.Random import get_random_bytes
         from Crypto.Util import Counter
         pad = lambda x: x + (PWENC_BLOCK_SIZE - len(x) % PWENC_BLOCK_SIZE) * PWENC_PADDING


### PR DESCRIPTION
Changes, similar to https://github.com/freenas/freenas/pull/307/commits/eed0021b5e7ef5a44577731336453db98f07d053